### PR TITLE
Fix Daylight Shavings Helmet sometimes undefined effect error

### DIFF
--- a/client/src/sections/resources/2021/DaylightShavingsHelmet.tsx
+++ b/client/src/sections/resources/2021/DaylightShavingsHelmet.tsx
@@ -11,7 +11,7 @@ const DaylightShavingsHelmet = () => {
     DaylightShavings.buffsUntil($effect`Friendly Chops`) ?? 0;
   const buffsTilItem =
     DaylightShavings.buffsUntil($effect`Spectacle Moustache`) ?? 0;
-  const nextBuff = DaylightShavings.nextBuff();
+  const nextBuff = DaylightShavings.nextBuff() ?? $effect`none`;
 
   // TO-DO LIST ON THIS TILE:
   //   - Figure out ways to cut tile length.


### PR DESCRIPTION
For some reason, libram's `DaylightShavings.nextBuff()` sometimes returns undefined. In my current character state it only seems to happen in early render cycles of this component, not consistently. I don't currently understand why that happens, but adding a safety check here fixes it and I'd like to get yorick working again.