### PR TITLE
Collapsible Tiles using Chakra's Collapsible Component

### DIFF
--- a/src/components/Tile.tsx
+++ b/src/components/Tile.tsx
@@ -1,4 +1,11 @@
-import { Box, HStack, IconButton, StackProps, VStack } from "@chakra-ui/react";
+import {
+  Box,
+  Collapsible,
+  HStack,
+  IconButton,
+  StackProps,
+  VStack,
+} from "@chakra-ui/react";
 import { decode } from "html-entities";
 import { Familiar, Item, Skill } from "kolmafia";
 import { ChevronDown, ChevronUp } from "lucide-react";
@@ -67,7 +74,7 @@ const Tile: FC<TileProps> = ({
     );
   }
 
-  const [collapsed, setCollapsed] = useLocalStorage(
+  const [collapsed, setCollapsed] = useLocalStorage<boolean>(
     `collapse-${storageId}`,
     false,
   );
@@ -125,7 +132,11 @@ const Tile: FC<TileProps> = ({
           )}
         </HStack>
       </HStack>
-      {!collapsed && !disabled && children}
+      {!disabled && (
+        <Collapsible.Root unmountOnExit open={!collapsed}>
+          <Collapsible.Content>{children}</Collapsible.Content>
+        </Collapsible.Root>
+      )}
     </VStack>
   );
 


### PR DESCRIPTION
I noticed visual studio code throwing me a little type error red flag in the Tile.tsx file, really inconsequential (the useLocalStorage hook didn't have a type parameter declared so it was inferring that it was false rather than boolean - no impact on anything really). I went to clear that up and just making sure I didn't break anything tested out the functionality in Yorick. I had the idea to try to animate the collapse functionality and it turns out Chakra has a [Collapsible component](https://www.chakra-ui.com/docs/components/collapsible) that makes it real easy. I'm actually not how you'd feel about it though, no hard feelings if the consensus is that this is just unnecessary fluff.

Unrelated question, good chance I'm wrong but are the collapse chevrons here inverted compared to how they're usually used?

https://github.com/user-attachments/assets/2004a15b-1f0e-4cef-bb47-02234641512e

